### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,6 +16,8 @@ jobs:
   # --- TESTING TASK ---
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
Potential fix for [https://github.com/s-kav/ds_tools/security/code-scanning/1](https://github.com/s-kav/ds_tools/security/code-scanning/1)

To fix the issue:
1. Add a `permissions` block explicitly to the `test` job to limit the permissions of the GITHUB_TOKEN to only what is necessary.
2. Based on the operations performed in the `test` job (installing dependencies and running tests), the minimal required permissions are `contents: read`.

This change ensures that the GITHUB_TOKEN used in the `test` job adheres to the principle of least privilege, reducing the repository's exposure to potential risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
